### PR TITLE
Fix `bundle exec rake`

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -31,7 +31,7 @@ Rails.application.configure do
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
-  config.action_mailer.delivery_method = :test
+  # config.action_mailer.delivery_method = :test
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr


### PR DESCRIPTION
It was failing with an error about action_mailer being missing. Our
application does not use action_mailer, so comment out the offending
configuration.