### PR TITLE
Bump ransack to 3.2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,9 +155,9 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
-    ransack (2.5.0)
-      activerecord (>= 5.2.4)
-      activesupport (>= 5.2.4)
+    ransack (3.2.1)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
       i18n
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -75,7 +75,7 @@ module UsersHelper
 
   def display_sort_column_headers(search)
     user_column_headers.reduce(String.new) do |string, field|
-      string << (tag.th sort_link(search, field, {}, method: action))
+      string << (tag.th sort_link(search, field, method: action))
     end +
     post_title_header_labels.reduce(String.new) do |str, i|
       str << (tag.th "Post #{i} title")


### PR DESCRIPTION
And fix deprecation:

```
Passing two trailing hashes to `sort_link` is deprecated, merge the
trailing hashes into a single one. (called at
/path/to/app/helpers/users_helper.rb:78)
````